### PR TITLE
Fix for .bib files & enhancing readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ This small script helps you to prepare a `LaTeX` project for publication e.g. on
 - `huepy` : `pip install huepy`
 - `glob2` : `pip install glob2`
 
+On Ubuntu, one can install the first three via: `sudo apt-get install texlive-extra-utils latexmk`.
+
 # Usage 
 
 ```bash

--- a/tex-publishing-util.py
+++ b/tex-publishing-util.py
@@ -178,8 +178,8 @@ def remove_redundant_files(project_dir, main_file, save_dir, debug):
 
 
     # Kind of fix
-    for fname in sum([glob.glob(f'{project_dir}/*.{x}') for x in ['bib', 'bst']], []):
-        shutil.copy(fname, save_dir)
+    for fname in sum([glob.glob1(project_dir, f'*.{x}') for x in ['bib', 'bst', 'bbl']], []):    # glob.glob1 is needed since glob.glob misinterprets '[',']','?' symbols
+        shutil.copy(os.path.join(project_dir, fname), save_dir)
 
 
 def extract_graphics_paths(project_dir, main_file, debug, flatten):


### PR DESCRIPTION
Experienced the already reported bug about not copied .bib files when using `--remove-redundant-fiels`
Turns out it was because filename contained square brackets, which are misinterpreted by glob.glob
Changed glob.glob to glob.glob1 in line L181 and made sure it works now