### PR TITLE
A fix for excessive replacements when doing remove-comments

### DIFF
--- a/tex-publishing-util.py
+++ b/tex-publishing-util.py
@@ -132,7 +132,7 @@ def change_paths(tex_file, files, flatten, convert_to_jpg):
         # Sometimes special symbols are used inside path, so let's try to find dir path
         dirnames_ = sorted(list(set([os.path.dirname(x) for x in files])))[::-1]
         for dir_path in dirnames_:
-            pattern = re.compile(dir_path)
+            pattern = re.compile(os.path.join(dir_path, ''))    # to replace e.g. "fig/" not "fig" with "." everywhere in the tex
             text, num = re.subn(pattern, lambda match: '.', text)
 
     


### PR DESCRIPTION
One more thing: noticed that when using `--flatten --remove-comments`, the directory name where the pictures were (e.g. "fig") is replaced everywhere in the text in L135-136, even where it's not needed. 
E.g. if I had pictures `fig/1.jpg`, `fig/2.jpg` in my repo, their mentions in the .tex file get replaced by `1.jpg` and `2.jpg`, but also the word `fig` gets replaced by `.` everywhere in the text (e.g. in `\begin{figure}` -> `\begin{.ure}`). 
Made a quick dirty fix to replace `dirname/` not `dirname` to `.` in L135-136.

Also maybe worth mentioning in the readme & help message that `--remove-comments` only works with `--flatten`